### PR TITLE
added long_description_content_type to setup.py call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     version='0.24.1',  # Required
 	description='Skycoin Python Library',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/simelo/pyskycoin',
     author='stdevEclipse',  # Optional
     author_email='dev0003@simelo.tech',


### PR DESCRIPTION
Fixes #33 

Changes:
- added `long_description_content_type` to `setup.py`  according to [PEP 566](https://www.python.org/dev/peps/pep-0566/)

Does this change need to mentioned in CHANGELOG.md?

No