### PR TITLE
fixes #74 - Typos in top-level heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PySkycoin
+# PySkycoin
 
 [![Build Status](https://travis-ci.org/skycoin/pyskycoin.svg?branch=develop)](https://travis-ci.org/skycoin/pyskycoin)
 


### PR DESCRIPTION
Fixes #74 

Changes:
- Fix typo in README heading 

Does this change need to mentioned in CHANGELOG.md?

No

