### PR TITLE
fixes #33 fixes #85 Correct rendering of PyPI page for release 0.25.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
     version=__version__,  # Required
     description="Skycoin Python Library",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/simelo/pyskycoin",
     author="Ratmil Torres",  # Optional
     author_email="skycoin@simelo.tech",


### PR DESCRIPTION
Fixes #33 fixes #85

Changes:
- Specify `long_description_content_type="text/markdown"` in `setup.py`

Does this change need to mentioned in CHANGELOG.md?

No

