### PR TITLE
refs #104 - Go lang for multilinux wheels

### DIFF
--- a/.travis/build_wheels.sh
+++ b/.travis/build_wheels.sh
@@ -4,6 +4,9 @@ set -e -x
 # Install a system package required by our library
 yum install -y atlas-devel
 
+sh /io/.travis/install_linux.sh
+eval "$(gimme 1.10)"
+
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
   "${PYBIN}/pip" install -r /io/requirements.dev.txt

--- a/.travis/install-linux.sh
+++ b/.travis/install-linux.sh
@@ -2,12 +2,17 @@
 
 set -ev
 
+# Repository root path
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+echo "Install Linux packages from $REPO_ROOT"
+
 # Install gimme
 curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 chmod +x ~/bin/gimme
 
 #Install Python libraries
-python -m pip install --upgrade pip setuptools wheel tox tox-travis tox-pyenv pytest pytest-runner
+python -m pip install --upgrade pip setuptools tox-travis
+python -m pip install --upgrade "$REPO_ROOT/requirements.dev.txt"
 
 # Compile SWIG
 mkdir swig_build && \

--- a/.travis/install-linux.sh
+++ b/.travis/install-linux.sh
@@ -12,7 +12,7 @@ chmod +x ~/bin/gimme
 
 #Install Python libraries
 python -m pip install --upgrade pip setuptools tox-travis
-python -m pip install --upgrade "$REPO_ROOT/requirements.dev.txt"
+python -m pip install -r "$REPO_ROOT/requirements.dev.txt"
 
 # Compile SWIG
 mkdir swig_build && \

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,7 @@
 
 pytest
 pytest-runner
+tox
+tox-pyenv
+wheel
 


### PR DESCRIPTION
refs #104 

Changes:
- Install golang using `gimme` for PyPA Docker containers to build `multilinux` wheels

Does this change need to mentioned in CHANGELOG.md?

No

